### PR TITLE
Fixed links to source code

### DIFF
--- a/tutorials/individual-tutorials/creating-menus/creating-menus.md
+++ b/tutorials/individual-tutorials/creating-menus/creating-menus.md
@@ -1460,15 +1460,15 @@ You can view the source code for this tutorial (including both examples) here:
 
 ### Switch-based example
 
-* [32blit (C++)](../../../source-code/individual-tutorials/creating-menus/switch-based-menu/32blit-cpp/)
-* [PicoSystem (C++)](../../../source-code/individual-tutorials/creating-menus/switch-based-menu/picosystem-cpp/)
-* [PicoSystem (MicroPython)](../../../source-code/individual-tutorials/creating-menus/switch-based-menu/picosystem-micropython/)
+* [32blit (C++)](https://github.com/32blit/32blit-tutorials-contrib/tree/main/source-code/individual-tutorials/creating-menus/switch-based-menu/32blit-cpp/)
+* [PicoSystem (C++)](https://github.com/32blit/32blit-tutorials-contrib/tree/main/source-code/individual-tutorials/creating-menus/switch-based-menu/picosystem-cpp/)
+* [PicoSystem (MicroPython)](https://github.com/32blit/32blit-tutorials-contrib/tree/main/source-code/individual-tutorials/creating-menus/switch-based-menu/picosystem-micropython/)
 
 ### State pattern example
 
-* [32blit (C++)](../../../source-code/individual-tutorials/creating-menus/state-pattern-menu/32blit-cpp/)
-* [PicoSystem (C++)](../../../source-code/individual-tutorials/creating-menus/state-pattern-menu/picosystem-cpp/)
-* [PicoSystem (MicroPython)](../../../source-code/individual-tutorials/creating-menus/state-pattern-menu/picosystem-micropython/)
+* [32blit (C++)](https://github.com/32blit/32blit-tutorials-contrib/tree/main/source-code/individual-tutorials/creating-menus/state-pattern-menu/32blit-cpp/)
+* [PicoSystem (C++)](https://github.com/32blit/32blit-tutorials-contrib/tree/main/source-code/individual-tutorials/creating-menus/state-pattern-menu/picosystem-cpp/)
+* [PicoSystem (MicroPython)](https://github.com/32blit/32blit-tutorials-contrib/tree/main/source-code/individual-tutorials/creating-menus/state-pattern-menu/picosystem-micropython/)
 
 ## Taking it further
 

--- a/tutorials/individual-tutorials/haptic-feedback/haptic-feedback.md
+++ b/tutorials/individual-tutorials/haptic-feedback/haptic-feedback.md
@@ -62,7 +62,7 @@ void update(uint32_t time) {
 }
 ```
 
-A slightly more developed version of this can be found in the [example code](../../../source-code/individual-tutorials/haptic-feedback/fading-amplitude/), which uses different starting amplitudes for different buttons, along with a visualisation of the current value of the `blit::vibration` variable:
+A slightly more developed version of this can be found in the [example code](https://github.com/32blit/32blit-tutorials-contrib/tree/main/source-code/individual-tutorials/haptic-feedback/fading-amplitude/), which uses different starting amplitudes for different buttons, along with a visualisation of the current value of the `blit::vibration` variable:
 
 ![](fading-amplitude.gif)
 
@@ -113,7 +113,7 @@ void update(uint32_t time) {
 
 > When initialising `current_position`, we set it to the size of `effect` so that the effect won't play as soon as the demo starts.
 
-The [example code for this section](../../../source-code/individual-tutorials/haptic-feedback/complex-effects/) has a much longer `effect` array, in order to demonstrate several of the effects which are made possible by you specifing the haptic effects on a frame-by-frame basis. Feel free to edit it in order to create your own effects!
+The [example code for this section](https://github.com/32blit/32blit-tutorials-contrib/tree/main/source-code/individual-tutorials/haptic-feedback/complex-effects/) has a much longer `effect` array, in order to demonstrate several of the effects which are made possible by you specifing the haptic effects on a frame-by-frame basis. Feel free to edit it in order to create your own effects!
 
 ## Tidying it up into a class
 
@@ -252,7 +252,7 @@ Don't forget to add the `#include` statement for our new class at the start of `
 #include "haptic_manager.hpp"
 ```
 
-In the [example code for this section](../../../source-code/individual-tutorials/haptic-feedback/haptic-manager/), there are some extra effects mapped to the D-pad buttons, along with the same visualisation code used in the other sections. As always, make sure to experiment by changing values and creating your own effects. You could always try improving the `HapticManager` interface, for example to add the ability to pause an effect which is currently playing.
+In the [example code for this section](https://github.com/32blit/32blit-tutorials-contrib/tree/main/source-code/individual-tutorials/haptic-feedback/haptic-manager/), there are some extra effects mapped to the D-pad buttons, along with the same visualisation code used in the other sections. As always, make sure to experiment by changing values and creating your own effects. You could always try improving the `HapticManager` interface, for example to add the ability to pause an effect which is currently playing.
 
 ## Summary
 
@@ -262,9 +262,9 @@ In this tutorial, we've looked at how to add haptic feedback to our games, befor
 
 You can view the source code for this tutorial here:
 
-* [Fading amplitude example](../../../source-code/individual-tutorials/haptic-feedback/fading-amplitude/)
-* [Complex effects example](../../../source-code/individual-tutorials/haptic-feedback/complex-effects/)
-* [Haptic manager example](../../../source-code/individual-tutorials/haptic-feedback/haptic-manager/)
+* [Fading amplitude example](https://github.com/32blit/32blit-tutorials-contrib/tree/main/source-code/individual-tutorials/haptic-feedback/fading-amplitude/)
+* [Complex effects example](https://github.com/32blit/32blit-tutorials-contrib/tree/main/source-code/individual-tutorials/haptic-feedback/complex-effects/)
+* [Haptic manager example](https://github.com/32blit/32blit-tutorials-contrib/tree/main/source-code/individual-tutorials/haptic-feedback/haptic-manager/)
 
 ## Taking it further
 

--- a/tutorials/individual-tutorials/making-noise/making-noise.md
+++ b/tutorials/individual-tutorials/making-noise/making-noise.md
@@ -112,7 +112,7 @@ void update(uint32_t time) {
 
 TODO talky? or not
 
-TODO The [example code for this section](../../../source-code/individual-tutorials/making-noise/playing-notes/) blah blah
+TODO The [example code for this section](https://github.com/32blit/32blit-tutorials-contrib/tree/main/source-code/individual-tutorials/making-noise/playing-notes/) blah blah
 
 
 ## RENAME: Playing MP3s
@@ -184,7 +184,7 @@ void update(uint32_t time) {
 }
 ```
 
-TODO: The [example code for this section](../../../source-code/individual-tutorials/making-noise/playing-mp3s/) blah blah
+TODO: The [example code for this section](https://github.com/32blit/32blit-tutorials-contrib/tree/main/source-code/individual-tutorials/making-noise/playing-mp3s/) blah blah
 
 ## RENAME: Playing WAVs
 

--- a/tutorials/ninja-thief/episode-1.md
+++ b/tutorials/ninja-thief/episode-1.md
@@ -505,9 +505,9 @@ We've now learnt everything we'll need to handle the rendering of our game. So f
 
 You can access the source code for the project so far here:
 
-* [32blit (C++)](../../source-code/ninja-thief/episode-1/32blit-cpp/)
-* [PicoSystem (C++)](../../source-code/ninja-thief/episode-1/picosystem-cpp/)
-* [PicoSystem (MicroPython)](../../source-code/ninja-thief/episode-1/picosystem-micropython/)
+* [32blit (C++)](https://github.com/32blit/32blit-tutorials-contrib/tree/main/source-code/ninja-thief/episode-1/32blit-cpp/)
+* [PicoSystem (C++)](https://github.com/32blit/32blit-tutorials-contrib/tree/main/source-code/ninja-thief/episode-1/picosystem-cpp/)
+* [PicoSystem (MicroPython)](https://github.com/32blit/32blit-tutorials-contrib/tree/main/source-code/ninja-thief/episode-1/picosystem-micropython/)
 
 Next episode, we will get the player moving and responding to input, as well as adding gravity.
 

--- a/tutorials/ninja-thief/episode-2.md
+++ b/tutorials/ninja-thief/episode-2.md
@@ -1157,9 +1157,9 @@ We've covered how to detect when buttons have been pressed, or when they are hel
 
 You can access the source code for the project so far here:
 
-* [32blit (C++)](../../source-code/ninja-thief/episode-2/32blit-cpp/)
-* [PicoSystem (C++)](../../source-code/ninja-thief/episode-2/picosystem-cpp/)
-* [PicoSystem (MicroPython)](../../source-code/ninja-thief/episode-2/picosystem-micropython/)
+* [32blit (C++)](https://github.com/32blit/32blit-tutorials-contrib/tree/main/source-code/ninja-thief/episode-2/32blit-cpp/)
+* [PicoSystem (C++)](https://github.com/32blit/32blit-tutorials-contrib/tree/main/source-code/ninja-thief/episode-2/picosystem-cpp/)
+* [PicoSystem (MicroPython)](https://github.com/32blit/32blit-tutorials-contrib/tree/main/source-code/ninja-thief/episode-2/picosystem-micropython/)
 
 Next episode, we will be looking at storing, loading, and rendering levels, along with the basics of collision detection and resolution.
 

--- a/tutorials/ninja-thief/episode-3.md
+++ b/tutorials/ninja-thief/episode-3.md
@@ -1613,9 +1613,9 @@ In this episode, we looked at how to store information about our level layout, a
 
 You can access the source code for the project so far here:
 
-* [32blit (C++)](../../source-code/ninja-thief/episode-3/32blit-cpp/)
-* [PicoSystem (C++)](../../source-code/ninja-thief/episode-3/picosystem-cpp/)
-* [PicoSystem (MicroPython)](../../source-code/ninja-thief/episode-3/picosystem-micropython/)
+* [32blit (C++)](https://github.com/32blit/32blit-tutorials-contrib/tree/main/source-code/ninja-thief/episode-3/32blit-cpp/)
+* [PicoSystem (C++)](https://github.com/32blit/32blit-tutorials-contrib/tree/main/source-code/ninja-thief/episode-3/picosystem-cpp/)
+* [PicoSystem (MicroPython)](https://github.com/32blit/32blit-tutorials-contrib/tree/main/source-code/ninja-thief/episode-3/picosystem-micropython/)
 
 Next episode, we will stop our player from being able to jump in midair, and add ladders which the player can climb up and down. We will also add enemies, starting off with making them patrol the platforms they spawn on, before allowing them to climb ladders as well.
 

--- a/tutorials/ninja-thief/episode-4.md
+++ b/tutorials/ninja-thief/episode-4.md
@@ -2767,9 +2767,9 @@ We've got a lot done this episode - ladders are now drawn to the screen, and the
 
 You can access the source code for the project so far here:
 
-* [32blit (C++)](../../source-code/ninja-thief/episode-4/32blit-cpp/)
-* [PicoSystem (C++)](../../source-code/ninja-thief/episode-4/picosystem-cpp/)
-* [PicoSystem (MicroPython)](../../source-code/ninja-thief/episode-4/picosystem-micropython/)
+* [32blit (C++)](https://github.com/32blit/32blit-tutorials-contrib/tree/main/source-code/ninja-thief/episode-4/32blit-cpp/)
+* [PicoSystem (C++)](https://github.com/32blit/32blit-tutorials-contrib/tree/main/source-code/ninja-thief/episode-4/picosystem-cpp/)
+* [PicoSystem (MicroPython)](https://github.com/32blit/32blit-tutorials-contrib/tree/main/source-code/ninja-thief/episode-4/picosystem-micropython/)
 
 In the final episode, we will make the player able to die (either by touching an enemy or falling off the screen). We add the ability for the player to collect the coins and gems (collecting all the coins will complete the level). We'll also add another level map, which starts once the player completes the previous one, along with some pipes in the background of each level. 
 

--- a/tutorials/ninja-thief/episode-5.md
+++ b/tutorials/ninja-thief/episode-5.md
@@ -3035,9 +3035,9 @@ In this episode, we've finally made our game completely playable. You can now co
 
 You can access the source code for the project here:
 
-* [32blit (C++)](../../source-code/ninja-thief/episode-5/32blit-cpp/)
-* [PicoSystem (C++)](../../source-code/ninja-thief/episode-5/picosystem-cpp/)
-* [PicoSystem (MicroPython)](../../source-code/ninja-thief/episode-5/picosystem-micropython/)
+* [32blit (C++)](https://github.com/32blit/32blit-tutorials-contrib/tree/main/source-code/ninja-thief/episode-5/32blit-cpp/)
+* [PicoSystem (C++)](https://github.com/32blit/32blit-tutorials-contrib/tree/main/source-code/ninja-thief/episode-5/picosystem-cpp/)
+* [PicoSystem (MicroPython)](https://github.com/32blit/32blit-tutorials-contrib/tree/main/source-code/ninja-thief/episode-5/picosystem-micropython/)
 
 ## What's next?
 


### PR DESCRIPTION
Links to source code should now correctly go to the github repo, instead of relative links.